### PR TITLE
ADR-1560 added filter to get rid of not due obligations

### DIFF
--- a/app/uk/gov/hmrc/alcoholdutyaccount/connectors/ObligationDataConnector.scala
+++ b/app/uk/gov/hmrc/alcoholdutyaccount/connectors/ObligationDataConnector.scala
@@ -107,7 +107,7 @@ class ObligationDataConnector @Inject() (
   private def filterOutFutureObligations(obligationData: ObligationData): ObligationData =
     obligationData.copy(obligations = obligationData.obligations.flatMap { obligation =>
       val filteredDetails: Seq[ObligationDetails] = obligation.obligationDetails.filter { obligationDetail =>
-        !obligationDetail.inboundCorrespondenceToDate.isAfter(LocalDate.now())
+        obligationDetail.inboundCorrespondenceToDate.isBefore(LocalDate.now())
       }
       // This code makes empty obligations of format ObligationData(obligations = Seq.empty), matching how they are currently returned
       if (filteredDetails.nonEmpty) Some(obligation.copy(obligationDetails = filteredDetails)) else None

--- a/test-common/uk/gov/hmrc/alcoholdutyaccount/common/TestData.scala
+++ b/test-common/uk/gov/hmrc/alcoholdutyaccount/common/TestData.scala
@@ -84,8 +84,11 @@ trait TestData extends ModelGenerators {
     periodKey = periodKey
   )
 
-  val obligationDetails2 = obligationDetails.copy(periodKey = periodKey2)
-  val obligationDetails3 = obligationDetails.copy(periodKey = periodKey3)
+  val obligationDetails2          = obligationDetails.copy(periodKey = periodKey2)
+  val obligationDetails3          = obligationDetails.copy(periodKey = periodKey3)
+  val obligationDetailsFromFuture =
+    obligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now().plusDays(1000))
+  val obligationDetailsFromToday  = obligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now())
 
   val obligationDataSingleOpen = ObligationData(
     obligations = Seq(
@@ -106,6 +109,22 @@ trait TestData extends ModelGenerators {
     )
   )
 
+  val openObligationDataFromToday = ObligationData(obligations =
+    Seq(
+      Obligation(
+        obligationDetails = Seq(obligationDetailsFromToday)
+      )
+    )
+  )
+
+  val openObligationDataFromFuture = ObligationData(obligations =
+    Seq(
+      Obligation(
+        obligationDetails = Seq(obligationDetailsFromFuture)
+      )
+    )
+  )
+
   val fulfilledObligationDetails = ObligationDetails(
     status = Fulfilled,
     inboundCorrespondenceFromDate = LocalDate.of(2024, 1, 1),
@@ -114,6 +133,11 @@ trait TestData extends ModelGenerators {
     inboundCorrespondenceDueDate = LocalDate.of(2024, 1, 1),
     periodKey = periodKey
   )
+
+  val fulfilledObligationDetailsFromFuture =
+    fulfilledObligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now().plusDays(1000))
+  val fulfilledObligationDetailsFromToday  =
+    fulfilledObligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now())
 
   val obligationDataSingleFulfilled          = ObligationData(
     obligations = Seq(
@@ -129,6 +153,22 @@ trait TestData extends ModelGenerators {
       ),
       Obligation(
         obligationDetails = Seq(fulfilledObligationDetails)
+      )
+    )
+  )
+
+  val fulfilledObligationDataFromToday = ObligationData(obligations =
+    Seq(
+      Obligation(
+        obligationDetails = Seq(fulfilledObligationDetailsFromToday)
+      )
+    )
+  )
+
+  val fulfilledObligationDataFromFuture = ObligationData(obligations =
+    Seq(
+      Obligation(
+        obligationDetails = Seq(fulfilledObligationDetailsFromFuture)
       )
     )
   )

--- a/test-common/uk/gov/hmrc/alcoholdutyaccount/common/TestData.scala
+++ b/test-common/uk/gov/hmrc/alcoholdutyaccount/common/TestData.scala
@@ -84,11 +84,12 @@ trait TestData extends ModelGenerators {
     periodKey = periodKey
   )
 
-  val obligationDetails2          = obligationDetails.copy(periodKey = periodKey2)
-  val obligationDetails3          = obligationDetails.copy(periodKey = periodKey3)
-  val obligationDetailsFromFuture =
+  val obligationDetails2            = obligationDetails.copy(periodKey = periodKey2)
+  val obligationDetails3            = obligationDetails.copy(periodKey = periodKey3)
+  val obligationDetailsFromFuture   =
     obligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now().plusDays(1000))
-  val obligationDetailsFromToday  = obligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now())
+  val obligationDetailsFromToday    = obligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now().minusDays(1))
+  val obligationDetailsFromTomorrow = obligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now())
 
   val obligationDataSingleOpen = ObligationData(
     obligations = Seq(
@@ -117,6 +118,14 @@ trait TestData extends ModelGenerators {
     )
   )
 
+  val openObligationDataFromTomorrow = ObligationData(obligations =
+    Seq(
+      Obligation(
+        obligationDetails = Seq(obligationDetailsFromTomorrow)
+      )
+    )
+  )
+
   val openObligationDataFromFuture = ObligationData(obligations =
     Seq(
       Obligation(
@@ -134,9 +143,11 @@ trait TestData extends ModelGenerators {
     periodKey = periodKey
   )
 
-  val fulfilledObligationDetailsFromFuture =
+  val fulfilledObligationDetailsFromFuture   =
     fulfilledObligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now().plusDays(1000))
-  val fulfilledObligationDetailsFromToday  =
+  val fulfilledObligationDetailsFromToday    =
+    fulfilledObligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now().minusDays(1))
+  val fulfilledObligationDetailsFromTomorrow =
     fulfilledObligationDetails.copy(inboundCorrespondenceToDate = LocalDate.now())
 
   val obligationDataSingleFulfilled          = ObligationData(
@@ -161,6 +172,14 @@ trait TestData extends ModelGenerators {
     Seq(
       Obligation(
         obligationDetails = Seq(fulfilledObligationDetailsFromToday)
+      )
+    )
+  )
+
+  val fulfilledObligationDataFromTomorrow = ObligationData(obligations =
+    Seq(
+      Obligation(
+        obligationDetails = Seq(fulfilledObligationDetailsFromTomorrow)
       )
     )
   )

--- a/test/uk/gov/hmrc/alcoholdutyaccount/connectors/ObligationDataConnectorSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyaccount/connectors/ObligationDataConnectorSpec.scala
@@ -44,6 +44,48 @@ class ObligationDataConnectorSpec extends SpecBase with ScalaFutures with Connec
         verifyGetWithParameters(url, expectedQueryParamsFulfilled)
       }
     }
+
+    "successfully filter out future open obligation data" in new SetUp {
+      stubGetWithParameters(url, expectedQueryParamsOpen, OK, Json.toJson(openObligationDataFromFuture).toString)
+      whenReady(connector.getObligationDetails(appaId, Some(obligationFilterOpen)).value) { result =>
+        result mustBe Right(noObligations)
+        verifyGetWithParameters(url, expectedQueryParamsOpen)
+      }
+    }
+
+    "successfully filter out future fulfilled obligation data" in new SetUp {
+      stubGetWithParameters(
+        url,
+        expectedQueryParamsFulfilled,
+        OK,
+        Json.toJson(fulfilledObligationDataFromFuture).toString
+      )
+      whenReady(connector.getObligationDetails(appaId, Some(obligationFilterFulfilled)).value) { result =>
+        result mustBe Right(noObligations)
+        verifyGetWithParameters(url, expectedQueryParamsFulfilled)
+      }
+    }
+    "successfully NOT filter out open obligation due today" in new SetUp {
+      stubGetWithParameters(url, expectedQueryParamsOpen, OK, Json.toJson(openObligationDataFromToday).toString)
+      whenReady(connector.getObligationDetails(appaId, Some(obligationFilterOpen)).value) { result =>
+        result mustBe Right(openObligationDataFromToday)
+        verifyGetWithParameters(url, expectedQueryParamsOpen)
+      }
+    }
+
+    "successfully NOT filter out fulfilled obligation due today" in new SetUp {
+      stubGetWithParameters(
+        url,
+        expectedQueryParamsFulfilled,
+        OK,
+        Json.toJson(fulfilledObligationDataFromToday).toString
+      )
+      whenReady(connector.getObligationDetails(appaId, Some(obligationFilterFulfilled)).value) { result =>
+        result mustBe Right(fulfilledObligationDataFromToday)
+        verifyGetWithParameters(url, expectedQueryParamsFulfilled)
+      }
+    }
+
     "successfully get open and fulfilled obligation data if there is no filter" in new SetUp {
       stubGetWithParameters(
         url,

--- a/test/uk/gov/hmrc/alcoholdutyaccount/connectors/ObligationDataConnectorSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyaccount/connectors/ObligationDataConnectorSpec.scala
@@ -65,7 +65,29 @@ class ObligationDataConnectorSpec extends SpecBase with ScalaFutures with Connec
         verifyGetWithParameters(url, expectedQueryParamsFulfilled)
       }
     }
-    "NOT filter out open obligation due from today" in new SetUp {
+
+    "successfully filter out open obligation which are not due yet (because the correspondence to date is today)" in new SetUp {
+      stubGetWithParameters(url, expectedQueryParamsOpen, OK, Json.toJson(openObligationDataFromTomorrow).toString)
+      whenReady(connector.getObligationDetails(appaId, Some(obligationFilterOpen)).value) { result =>
+        result mustBe Right(noObligations)
+        verifyGetWithParameters(url, expectedQueryParamsOpen)
+      }
+    }
+
+    "successfully filter out open fulfilled which are not due yet (because the correspondence to date is today)" in new SetUp {
+      stubGetWithParameters(
+        url,
+        expectedQueryParamsFulfilled,
+        OK,
+        Json.toJson(fulfilledObligationDataFromTomorrow).toString
+      )
+      whenReady(connector.getObligationDetails(appaId, Some(obligationFilterFulfilled)).value) { result =>
+        result mustBe Right(noObligations)
+        verifyGetWithParameters(url, expectedQueryParamsFulfilled)
+      }
+    }
+
+    "NOT filter out open obligation due from today (because the correspondence to date was yesterday)" in new SetUp {
       stubGetWithParameters(url, expectedQueryParamsOpen, OK, Json.toJson(openObligationDataFromToday).toString)
       whenReady(connector.getObligationDetails(appaId, Some(obligationFilterOpen)).value) { result =>
         result mustBe Right(openObligationDataFromToday)
@@ -73,7 +95,7 @@ class ObligationDataConnectorSpec extends SpecBase with ScalaFutures with Connec
       }
     }
 
-    "NOT filter out fulfilled obligation due from today" in new SetUp {
+    "NOT filter out fulfilled obligation due from today (because the correspondence to date was yesterday)" in new SetUp {
       stubGetWithParameters(
         url,
         expectedQueryParamsFulfilled,

--- a/test/uk/gov/hmrc/alcoholdutyaccount/connectors/ObligationDataConnectorSpec.scala
+++ b/test/uk/gov/hmrc/alcoholdutyaccount/connectors/ObligationDataConnectorSpec.scala
@@ -65,7 +65,7 @@ class ObligationDataConnectorSpec extends SpecBase with ScalaFutures with Connec
         verifyGetWithParameters(url, expectedQueryParamsFulfilled)
       }
     }
-    "successfully NOT filter out open obligation due today" in new SetUp {
+    "NOT filter out open obligation due from today" in new SetUp {
       stubGetWithParameters(url, expectedQueryParamsOpen, OK, Json.toJson(openObligationDataFromToday).toString)
       whenReady(connector.getObligationDetails(appaId, Some(obligationFilterOpen)).value) { result =>
         result mustBe Right(openObligationDataFromToday)
@@ -73,7 +73,7 @@ class ObligationDataConnectorSpec extends SpecBase with ScalaFutures with Connec
       }
     }
 
-    "successfully NOT filter out fulfilled obligation due today" in new SetUp {
+    "NOT filter out fulfilled obligation due from today" in new SetUp {
       stubGetWithParameters(
         url,
         expectedQueryParamsFulfilled,


### PR DESCRIPTION
Ticket: [ADR-1560](https://jira.tools.tax.service.gov.uk/browse/ADR-1560). ETMP is making obligations before we thought they were. Therefore, we shall filter out obligations that they are making early, and will therefore not be due yet. I did this at the connector level so that it will filter out everything that we will get back API 1330, therefore all open and fulfilled obligations :)